### PR TITLE
Fix Larva Build Queue

### DIFF
--- a/actions.h
+++ b/actions.h
@@ -878,6 +878,9 @@ struct action_functions: state_functions {
 				if (!unit_can_build(u, unit_type)) continue;
 			} else continue;
 			if (u->order_type->id == Orders::ZergUnitMorph) continue;
+			while (!u->build_queue.emtpy()) {
+				u->build_queue.erase(u->build_queue.begin());
+			}
 			if (!build_queue_push(u, unit_type)) continue;
 			set_unit_order(u, get_order_type(Orders::ZergUnitMorph));
 			retval = true;


### PR DESCRIPTION
Fixes issue where a Larva's build queue can have hanging items causing problems with morph commands on the larva or Hydralisks and Mutalisks by having a morph command and stop command issued on the same frame. This ensures the build_queue is clear before attempting to add the desired unit type to the build_queue.

Directly erasing maintains the 1.16.1 behavior of the resources still being consumed by this situation, while keeping the larva and it's future unit type functioning properly as in 1.16.1.